### PR TITLE
Adding retries for Licensing Failure

### DIFF
--- a/Modules/ArcGIS/ArcGISUtility.psm1
+++ b/Modules/ArcGIS/ArcGISUtility.psm1
@@ -333,11 +333,25 @@ function License-Software
     Write-Verbose "[Running Command] $SoftwareAuthExePath $Params" -Verbose
     
     if($StdOutputLogFilePath) {
-        Start-Process -FilePath $SoftwareAuthExePath -ArgumentList $Params -Wait -RedirectStandardOutput $StdOutputLogFilePath -RedirectStandardError $StdErrLogFilePath
-		[string]$LicenseFileOutput = Get-Content $StdOutputLogFilePath
-		if($LicenseFileOutput -and (($LicenseFileOutput.IndexOf('Error') -gt -1) -or ($LicenseFileOutput.IndexOf('(null)') -gt -1))) {
-			throw "Licensing for Product [$Product] failed. Software Authorization Utility returned $LicenseFileOutput"
-		}
+        [bool]$Done = $false
+        [int]$AttemptNumber = 1
+        $err = $null
+        while(-not($Done) -and ($AttemptNumber -le 10)) {
+            Start-Process -FilePath $SoftwareAuthExePath -ArgumentList $Params -Wait -RedirectStandardOutput $StdOutputLogFilePath -RedirectStandardError $StdErrLogFilePath
+            [string]$LicenseFileOutput = Get-Content $StdOutputLogFilePath
+            if($LicenseFileOutput -and (($LicenseFileOutput.IndexOf('Error') -gt -1) -or ($LicenseFileOutput.IndexOf('(null)') -gt -1))) {
+                $err = "[ERROR] - Attempt $AttemptNumber - Licensing for Product [$Product] failed. Software Authorization Utility returned $LicenseFileOutput"
+                Write-Verbose $err
+                Start-Sleep -Seconds 30
+            }else{
+                $Done = $True
+                $err = $null
+            }
+            $AttemptNumber += 1
+        }
+        if($err -ne $null){
+            throw $err
+        }
 	}
     else {
         Start-Process -FilePath $SoftwareAuthExePath -ArgumentList $Params


### PR DESCRIPTION
#52 Licensing Failure happens if Concurrent requests to the Authorization Server are made. To Overcome this issue retires are being added.