### PR TITLE
Quote installer arguments

### DIFF
--- a/Modules/ArcGIS/Configuration/ArcGISInstall.ps1
+++ b/Modules/ArcGIS/Configuration/ArcGISInstall.ps1
@@ -70,7 +70,7 @@ Configuration ArcGISInstall{
                         Name = "Server"
                         Version = $ConfigurationData.ConfigData.Version
                         Path = $ConfigurationData.ConfigData.Server.Installer.Path
-                        Arguments = "/qn InstallDir=$($ConfigurationData.ConfigData.Server.Installer.InstallDir) INSTALLDIR1=$($ConfigurationData.ConfigData.Server.Installer.InstallDirPython)";
+                        Arguments = "/qn INSTALLDIR=`"$($ConfigurationData.ConfigData.Server.Installer.InstallDir)`" INSTALLDIR1=`"$($ConfigurationData.ConfigData.Server.Installer.InstallDirPython)`" USER_NAME=$($ConfigurationData.ConfigData.Credentials.ServiceAccount.UserName) PASSWORD=$($ConfigurationData.ConfigData.Credentials.ServiceAccount.Password)";
                         Ensure = "Present"
                     }
 
@@ -137,7 +137,7 @@ Configuration ArcGISInstall{
                         Name = "Portal"
                         Version = $ConfigurationData.ConfigData.Version
                         Path = $ConfigurationData.ConfigData.Portal.Installer.Path
-                        Arguments = "/qn INSTALLDIR=$($ConfigurationData.ConfigData.Portal.Installer.InstallDir) CONTENTDIR=$($ConfigurationData.ConfigData.Portal.Installer.ContentDir)";
+                        Arguments = "/qn INSTALLDIR=`"$($ConfigurationData.ConfigData.Portal.Installer.InstallDir)`" CONTENTDIR=`"$($ConfigurationData.ConfigData.Portal.Installer.ContentDir)`" USER_NAME=$($ConfigurationData.ConfigData.Credentials.ServiceAccount.UserName) PASSWORD=$($ConfigurationData.ConfigData.Credentials.ServiceAccount.Password)";
                         Ensure = "Present"
                     }
 
@@ -158,7 +158,7 @@ Configuration ArcGISInstall{
                         Name = "DataStore"
                         Version = $ConfigurationData.ConfigData.Version
                         Path = $ConfigurationData.ConfigData.DataStore.Installer.Path
-                        Arguments = "/qn InstallDir=$($ConfigurationData.ConfigData.DataStore.Installer.InstallDir)"
+                        Arguments = "/qn INSTALLDIR=`"$($ConfigurationData.ConfigData.DataStore.Installer.InstallDir)`" USER_NAME=$($ConfigurationData.ConfigData.Credentials.ServiceAccount.UserName) PASSWORD=$($ConfigurationData.ConfigData.Credentials.ServiceAccount.Password)";
                         Ensure = "Present"
                     }
 

--- a/Modules/ArcGIS/Configuration/ArcGISInstall.ps1
+++ b/Modules/ArcGIS/Configuration/ArcGISInstall.ps1
@@ -70,7 +70,7 @@ Configuration ArcGISInstall{
                         Name = "Server"
                         Version = $ConfigurationData.ConfigData.Version
                         Path = $ConfigurationData.ConfigData.Server.Installer.Path
-                        Arguments = "/qn INSTALLDIR=`"$($ConfigurationData.ConfigData.Server.Installer.InstallDir)`" INSTALLDIR1=`"$($ConfigurationData.ConfigData.Server.Installer.InstallDirPython)`" USER_NAME=$($ConfigurationData.ConfigData.Credentials.ServiceAccount.UserName) PASSWORD=$($ConfigurationData.ConfigData.Credentials.ServiceAccount.Password)";
+                        Arguments = "/qn INSTALLDIR=`"$($ConfigurationData.ConfigData.Server.Installer.InstallDir)`" INSTALLDIR1=`"$($ConfigurationData.ConfigData.Server.Installer.InstallDirPython)`"";
                         Ensure = "Present"
                     }
 
@@ -137,7 +137,7 @@ Configuration ArcGISInstall{
                         Name = "Portal"
                         Version = $ConfigurationData.ConfigData.Version
                         Path = $ConfigurationData.ConfigData.Portal.Installer.Path
-                        Arguments = "/qn INSTALLDIR=`"$($ConfigurationData.ConfigData.Portal.Installer.InstallDir)`" CONTENTDIR=`"$($ConfigurationData.ConfigData.Portal.Installer.ContentDir)`" USER_NAME=$($ConfigurationData.ConfigData.Credentials.ServiceAccount.UserName) PASSWORD=$($ConfigurationData.ConfigData.Credentials.ServiceAccount.Password)";
+                        Arguments = "/qn INSTALLDIR=`"$($ConfigurationData.ConfigData.Portal.Installer.InstallDir)`" CONTENTDIR=`"$($ConfigurationData.ConfigData.Portal.Installer.ContentDir)`"";
                         Ensure = "Present"
                     }
 
@@ -158,7 +158,7 @@ Configuration ArcGISInstall{
                         Name = "DataStore"
                         Version = $ConfigurationData.ConfigData.Version
                         Path = $ConfigurationData.ConfigData.DataStore.Installer.Path
-                        Arguments = "/qn INSTALLDIR=`"$($ConfigurationData.ConfigData.DataStore.Installer.InstallDir)`" USER_NAME=$($ConfigurationData.ConfigData.Credentials.ServiceAccount.UserName) PASSWORD=$($ConfigurationData.ConfigData.Credentials.ServiceAccount.Password)";
+                        Arguments = "/qn INSTALLDIR=`"$($ConfigurationData.ConfigData.DataStore.Installer.InstallDir)`"";
                         Ensure = "Present"
                     }
 

--- a/Modules/ArcGIS/DSCResources/ArcGIS_Install/ArcGIS_Install.psm1
+++ b/Modules/ArcGIS/DSCResources/ArcGIS_Install/ArcGIS_Install.psm1
@@ -137,7 +137,7 @@ function Set-TargetResource
                     $SetupExe = Get-ChildItem -Path $TempFolder -Filter '*.msi' -Recurse | Select-Object -First 1
                     $ExecPath = $SetupExe.FullName
                     if(-not($ExecPath) -or (-not(Test-Path $ExecPath))) {
-                            throw "Neither .exe nor .msi not found in extracted contents to install"
+                            throw "Neither .exe nor .msi found in extracted contents to install"
                     }               
                 }               
             }


### PR DESCRIPTION
Issues:

* Setup failed when installing to a directory containing spaces.
* Double negation in exception message.

Changes:

* Quotes INSTALLDIR paths to allow for spaces in directory names.
* Removed a erronous **not** in exception message. 