### PR TITLE
Add support for ArcGIS Monitor installation

### DIFF
--- a/Modules/ArcGIS/ArcGISUtility.psm1
+++ b/Modules/ArcGIS/ArcGISUtility.psm1
@@ -1438,7 +1438,7 @@ function Get-ComponentCode
        [CmdletBinding()]
        param
        (
-        [ValidateSet("Server","Portal","DataStore","GeoEvent","NotebookServer")]
+        [ValidateSet("Server","Portal","DataStore","GeoEvent","NotebookServer","Monitor")]
         [parameter(Mandatory = $true)]
         [System.String]
               $ComponentName,
@@ -1488,6 +1488,9 @@ function Get-ComponentCode
         }
         NotebookServer = @{
             '10.7' = '3721E3C6-6302-4C74-ACA4-5F50B1E1FE3A'
+        }
+        Monitor = @{
+            '10.7' = '0497042F-0CBB-40C0-8F62-F1922B90E12E'
         }
     }
     $ProductCodes[$ComponentName][$Version]    

--- a/Modules/ArcGIS/DSCResources/ArcGIS_Install/ArcGIS_Install.schema.mof
+++ b/Modules/ArcGIS/DSCResources/ArcGIS_Install/ArcGIS_Install.schema.mof
@@ -2,7 +2,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("ArcGIS_Install")]
 class ArcGIS_Install : OMI_BaseResource
 {
-	[Key, ValueMap{"Server","Portal","DataStore","GeoEvent","NotebookServer","Monitor"}, Values{"Server","Portal","DataStore","GeoEvent","NotebookServer","Monitor"}] String Name;
+	[Key] String Name;
 	[Write] String Path;
 	[Key] String Version;
 	[Write] String Arguments;

--- a/Modules/ArcGIS/DSCResources/ArcGIS_Install/ArcGIS_Install.schema.mof
+++ b/Modules/ArcGIS/DSCResources/ArcGIS_Install/ArcGIS_Install.schema.mof
@@ -2,7 +2,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("ArcGIS_Install")]
 class ArcGIS_Install : OMI_BaseResource
 {
-	[Key] String Name;
+	[Key, ValueMap{"Server","Portal","DataStore","GeoEvent","NotebookServer","Monitor"}, Values{"Server","Portal","DataStore","GeoEvent","NotebookServer","Monitor"}] String Name;
 	[Write] String Path;
 	[Key] String Version;
 	[Write] String Arguments;


### PR DESCRIPTION
Added support for ArcGIS Monitor as it is now an official product. Installation was tested with ArcGIS_Install successfully using below properties to install just the ArcGIS Monitor Administrator.

 ```
ArcGIS_Install Monitor {
    Name = "Monitor"
    Path = (Join-Path $(Get-Location).Path $MonitorFileName)
    Version = '10.7'
    Arguments = "/qn /norestart ADDLOCAL=Administrator"
    Ensure = 'Present'
    DependsOn = $Depends
}
$Depends += '[ArcGIS_Install]Monitor'
```