### PR TITLE
New property to enable/disable the Portal service directory

### DIFF
--- a/Modules/ArcGIS/DSCResources/ArcGIS_Portal/ArcGIS_Portal.schema.mof
+++ b/Modules/ArcGIS/DSCResources/ArcGIS_Portal/ArcGIS_Portal.schema.mof
@@ -23,6 +23,7 @@ class ArcGIS_Portal : OMI_BaseResource
     [Write] String ContentDirectoryCloudConnectionString;
     [Write] String ContentDirectoryCloudContainerName; 
 	[Write, EmbeddedInstance("MSFT_Credential")] String ADServiceUser;
-	[Write] Boolean EnableAutomaticAccountCreation;   
+	[Write] Boolean EnableAutomaticAccountCreation;
+	[Write, Description("Is Service Directory Disabled")] Boolean DisableServiceDirectory; 
 };
 


### PR DESCRIPTION
Based on Esri best practices, I have added a new property to the ArcGIS_Portal resource to enable or disable the services directory. I noticed that some of the existing properties such as `EnableAutomaticAccountCreation` will only get evaluated during `Test-TargetResource` if they are set to `$true` which means that if DSC is used to switch these settings back and forth when needed instead of just at initial configuration time, they would not get changed based on the configuration property values. To get around this issue, I used a slightly different logic.

Also updated an incorrect variable name that was causing output to not show correctly.