### PR TITLE
Support for setting a sharedKey in ArcGIS Server

### DIFF
--- a/Modules/ArcGIS/DSCResources/ArcGIS_Server/ArcGIS_Server.schema.mof
+++ b/Modules/ArcGIS/DSCResources/ArcGIS_Server/ArcGIS_Server.schema.mof
@@ -15,5 +15,6 @@ class ArcGIS_Server : OMI_BaseResource
 	[Write] String Platform;
 	[Write, Description("Is Service Directory Disabled")] Boolean DisableServiceDirectory;
 	[Write, Description("Enable Usage Metering")] Boolean EnableUsageMetering;
+	[Write] String SharedKey;
 };
 


### PR DESCRIPTION
This functionality is needed when using siloed architecture as the shared key should match between the siloed sites to prevent authentication failures if end users are not generating new tokens before each and every request.