### PR TITLE
added support for a standalone license manager server role

### DIFF
--- a/Modules/ArcGIS/ArcGIS.psm1
+++ b/Modules/ArcGIS/ArcGIS.psm1
@@ -581,7 +581,7 @@ function Invoke-ArcGISConfiguration
     )
     
     $DebugMode = if($DebugSwitch){ $True }else{ $False } 
-
+    
     if(@("Install","InstallLicense","InstallLicenseConfigure","Uninstall") -icontains $Mode){
         $ConfigurationParamsJSON = $null
         Foreach($cf in $ConfigurationParametersFile){
@@ -778,8 +778,7 @@ function Invoke-ArcGISConfiguration
                     }
                 }
                 
-                if(-not($EnterpriseSkipLicenseStep -and $DesktopSkipLicenseStep -and $ProSkipLicenseStep)){
-
+                if(-not($EnterpriseSkipLicenseStep -and $DesktopSkipLicenseStep -and $ProSkipLicenseStep) -or($ConfigurationParamsHashtable.ConfigData.LicenseManager)){
                     $LicenseCD = @{
                         AllNodes = @() 
                     }
@@ -898,6 +897,10 @@ function Invoke-ArcGISConfiguration
                             if($ConfigurationParamsHashtable.ConfigData.Pro){
                                 $NodeToAdd["ProLicenseFilePath"] = $ConfigurationParamsHashtable.ConfigData.Pro.LicenseFilePath
                                 $NodeToAdd["ProVersion"] = $ConfigurationParamsHashtable.ConfigData.ProVersion
+                            }
+                            if($ConfigurationParamsHashtable.ConfigData.LicenseManager){
+                                $NodeToAdd["LicenseFilePath"] = $ConfigurationParamsHashtable.ConfigData.LicenseManager.LicenseFilePath
+                                $NodeToAdd["LicenseManagerVersion"] = $ConfigurationParamsHashtable.ConfigData.LicenseManagerVersion
                             }
                         }
                         if($NodeToAdd.Role.Count -gt 0){

--- a/Modules/ArcGIS/ArcGISUtility.psm1
+++ b/Modules/ArcGIS/ArcGISUtility.psm1
@@ -450,6 +450,11 @@ function Invoke-LicenseSoftware
                 $SoftwareAuthExePath = "$($LMInstallLocation)bin\SoftwareAuthorizationLS.exe"
             }
         }
+    } elseif ($Product -ieq 'LM') { # add standalone license manager as a server role
+        $LMInstallLocation = (Get-CimInstance Win32_Product| Where-Object {$_.Name -match "License Manager" -and $_.Vendor -eq 'Environmental Systems Research Institute, Inc.'}).InstallLocation
+        if($LMInstallLocation){
+            $SoftwareAuthExePath = "$($LMInstallLocation)bin\SoftwareAuthorizationLS.exe"
+        }
     }else{
         if($Product -ieq "Server" -and ($ServerRole -ieq "NotebookServer" -or $ServerRole -ieq "MissionServer" ) -and ($Version.Split('.')[1] -ge 8)){
             $ServerTypeName = "Server"

--- a/Modules/ArcGIS/Configurations-OnPrem/ArcGISLicense.ps1
+++ b/Modules/ArcGIS/Configurations-OnPrem/ArcGISLicense.ps1
@@ -93,6 +93,17 @@ Configuration ArcGISLicense
                             Force = $ForceLicenseUpdate
                         }
                     }
+                    if($Node.LicenseManagerVersion -and $Node.LicenseFilePath){ #standalone license manager server role
+                        ArcGIS_License "LMLicense$($Node.NodeName)"
+                        {
+                            LicenseFilePath = $Node.LicenseFilePath
+                            LicensePassword = $null
+                            Ensure = "Present"
+                            Component = 'LM'
+                            Version = $Node.LicenseManagerVersion #Ignored, will default to 10.6 in ArcGIS_License.psm1
+                            Force = $ForceLicenseUpdate
+                        }
+                    }
                 }
             }
         }

--- a/Modules/ArcGIS/DSCResources/ArcGIS_License/ArcGIS_License.psm1
+++ b/Modules/ArcGIS/DSCResources/ArcGIS_License/ArcGIS_License.psm1
@@ -58,7 +58,7 @@ function Set-TargetResource
 		[System.String]
 		$Ensure,
 
-        [ValidateSet("Server","Portal","Desktop","Pro")]
+        [ValidateSet("Server","Portal","Desktop","Pro","LM")]
 		[System.String]
 		$Component,
 
@@ -103,7 +103,7 @@ function Set-TargetResource
         }
         Write-Verbose "RealVersion of ArcGIS Software:- $RealVersion" 
         $RealVersion = $RealVersion.Split('.')[0] + '.' + $RealVersion.Split('.')[1] 
-        $LicenseVersion = if($Component -ieq 'Pro'){ '10.6' }else{ $RealVersion }
+        $LicenseVersion = if($Component -ieq 'Pro' -or $Component -ieq 'LM'){ '10.6' }else{ $RealVersion }
 
         Write-Verbose "Licensing from $LicenseFilePath" 
         if($Component -ieq 'Desktop' -or $Component -ieq 'Pro') {
@@ -148,7 +148,7 @@ function Test-TargetResource
 		[System.String]
 		$Ensure,
 
-		[ValidateSet("Server","Portal","Desktop","Pro")]
+		[ValidateSet("Server","Portal","Desktop","Pro","LM")]
 		[System.String]
 		$Component,
 

--- a/Modules/ArcGIS/DSCResources/ArcGIS_License/ArcGIS_License.schema.mof
+++ b/Modules/ArcGIS/DSCResources/ArcGIS_License/ArcGIS_License.schema.mof
@@ -6,7 +6,7 @@ class ArcGIS_License : OMI_BaseResource
 	[Write, Description("Optional License Password if applicable"), EmbeddedInstance("MSFT_Credential")] String LicensePassword;
 	[Write, Description("Optional Version associated with License (If using License Manger)")] String Version;
 	[Write, ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-	[Write, ValueMap{"Server","Portal","Desktop","Pro"}, Values{"Server","Portal","Desktop","Pro"}] String Component;
+	[Write, ValueMap{"Server","Portal","Desktop","Pro","LM"}, Values{"Server","Portal","Desktop","Pro","LM"}] String Component;
 	[Write, ValueMap{"ImageServer","GeoEvent","GeoAnalytics","GeneralPurposeServer","HostingServer", "NotebookServer","MissionServer"}, Values{"ImageServer","GeoEvent","GeoAnalytics","GeneralPurposeServer","HostingServer","NotebookServer","MissionServer"}] String ServerRole;
 	[Write, Description("Is Pro or Desktop using Single Use License")] Boolean IsSingleUse;
 	[Write, Description("Forcing to License")] Boolean Force;

--- a/SampleConfigs/v3/DesktopPro/LicenseManager-ServerRole.json
+++ b/SampleConfigs/v3/DesktopPro/LicenseManager-ServerRole.json
@@ -1,0 +1,20 @@
+{
+    "AllNodes": [
+        {
+            "NodeName": "[localhost -- Server where License Manager will be installed]",
+            "Role": [
+                "LicenseManager"
+            ]
+        }
+    ],
+    "ConfigData": {
+        "LicenseManagerVersion": "[Version of License Manager -- 2019.2, 2020.0, etc.]",
+        "LicenseManager": {
+            "LicenseFilePath": "[License File Path (*.prvs) - License Manager ]",
+            "Installer": {
+                "Path": "[License Manager Installer Path]",
+                "InstallDir": "[License Install Dir - Ex. C:\\ArcGIS\\LM]"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This feature allows the configuration of a "license manager" role that can be deployed standalone (ie. not with desktop or pro). This was at a customers request.