### PR TITLE
Support for Point In Time Recovery

### DIFF
--- a/Modules/ArcGIS/Configurations-Azure-2/DataStoreConfiguration.ps1
+++ b/Modules/ArcGIS/Configurations-Azure-2/DataStoreConfiguration.ps1
@@ -58,6 +58,11 @@
         ,[Parameter(Mandatory=$false)]
         [System.String]
         $DebugMode
+
+        ,[Parameter(Mandatory=$false)]
+        [System.String]
+        [ValidateSet('Enabled','Disabled','NotManaged')]
+        $PointInTimeRecovery = 'NotManaged'
     )
     
     Import-DscResource -ModuleName PSDesiredStateConfiguration 
@@ -204,8 +209,9 @@
                 RunAsAccount               = $ServiceCredential 
                 DataStoreTypes             = @('Relational')
                 IsEnvAzure                 = $true
-			    DependsOn                  = $DataStoreDependsOn
-		    } 
+                PITRState                  = $PointInTimeRecovery
+                DependsOn                  = $DataStoreDependsOn
+            }
 
 		    foreach($ServiceToStop in  @('ArcGIS Server', 'Portal for ArcGIS', 'ArcGISGeoEvent', 'ArcGISGeoEventGateway', 'ArcGIS Notebook Server'))
 		    {

--- a/Modules/ArcGIS/Configurations-Azure-2/TileCacheDataStoreConfiguration.ps1
+++ b/Modules/ArcGIS/Configurations-Azure-2/TileCacheDataStoreConfiguration.ps1
@@ -49,7 +49,11 @@ Configuration TileCacheDataStoreConfiguration{
         ,[Parameter(Mandatory=$false)]
         [System.String]
         $FileShareName = 'fileshare' 
-        
+ 
+        ,[Parameter(Mandatory=$false)]
+        [System.String]
+        $DataStoreBackupLocation = 'NotManaged'
+
         ,[Parameter(Mandatory=$false)]
         [System.String]
         $DebugMode
@@ -197,14 +201,16 @@ Configuration TileCacheDataStoreConfiguration{
 
             ArcGIS_DataStore TileCacheDataStore
             {
-                Ensure				= 'Present'
-                SiteAdministrator	= $SiteAdministratorCredential 
-                ServerHostName		= $ServerMachineName
-                ContentDirectory	= $DataStoreContentDirectory
-                DataStoreTypes		= $DataStoreTypes
-                IsEnvAzure          = $true
-                IsTileCacheDataStoreClustered = $IsTileCacheDataStoreClustered
-                DependsOn			= $DataStoreDependsOn
+                Ensure				            = 'Present'
+                SiteAdministrator	            = $SiteAdministratorCredential 
+                ServerHostName		            = $ServerMachineName
+                ContentDirectory	            = $DataStoreContentDirectory
+                DatabaseBackupsDirectory        = $DataStoreBackupLocation 
+                RunAsAccount                    = $ServiceCredential                 
+                DataStoreTypes		            = $DataStoreTypes
+                IsEnvAzure                      = $true
+                IsTileCacheDataStoreClustered   = $IsTileCacheDataStoreClustered
+                DependsOn			            = $DataStoreDependsOn
             }
             
             foreach($ServiceToStop in @( 'ArcGIS Server', 'Portal for ArcGIS', 'ArcGISGeoEvent', 'ArcGISGeoEventGateway', 'ArcGIS Notebook Server'))

--- a/Modules/ArcGIS/DSCResources/ArcGIS_DataStore/ArcGIS_DataStore.schema.mof
+++ b/Modules/ArcGIS/DSCResources/ArcGIS_DataStore/ArcGIS_DataStore.schema.mof
@@ -14,5 +14,6 @@ class ArcGIS_DataStore : OMI_BaseResource
 	[Write, Description("Is Standby instance")] Boolean IsStandby;
 	[Write, Description("Is Tile Cache DataStore Clustered")] Boolean IsTileCacheDataStoreClustered;
 	[Write, Description("Is Environment Azure")] Boolean IsEnvAzure;
+	[Write, ValueMap{"Enabled","Disabled","NotManaged"}, Values{"Enabled","Disabled","NotManaged"}] String PITRState;
 };
 


### PR DESCRIPTION
Added PointInTimeRecovery param in DataStoreConfig. Param can have value Enabled, Disabled and NotManaged for backward compatibility. DataStore DSC resource sets PITR using tools\changedbproperties.bat.  Backup location variable needs to be set when enabling PITR so DatabaseBackupsDirectory parameter is used. Lastly to set set the backup location the configurebackuplocation.bat script is used instead of changebackuplocation.bat (which is obsolete).