### PR TITLE
Fix issue #328 - Add user to "Log on as service"

### DIFF
--- a/Modules/ArcGIS/Configurations-OnPrem/ArcGISServer.ps1
+++ b/Modules/ArcGIS/Configurations-OnPrem/ArcGISServer.ps1
@@ -112,6 +112,7 @@ Configuration ArcGISServer
     Import-DSCResource -ModuleName @{ModuleName="ArcGIS";ModuleVersion="3.2.0"}
     Import-DscResource -Name ArcGIS_xFirewall
     Import-DscResource -Name ArcGIS_Server
+    Import-DscResource -Name ArcGIS_WindowsService
     Import-DscResource -Name ArcGIS_Service_Account
     Import-DscResource -Name ArcGIS_GeoEvent
 
@@ -262,6 +263,17 @@ Configuration ArcGISServer
                 }
             }
         }
+
+        # Issue-328: Service account no longer able to "Log on as Service"
+        ArcGIS_WindowsService ArcGIS_for_Server_Service
+        {
+            Name = 'ArcGIS Server'
+            Credential = $ServiceCredential
+            StartupType = 'Automatic'
+            State = 'Running'
+            DependsOn = $Depends
+        }
+        $Depends += '[ArcGIS_WindowsService]ArcGIS_for_Server_Service'
 
         $DataDirs = @()
         if($null -ne $CloudStorageType){


### PR DESCRIPTION
In version 3.1.1 of the dsc module, this was already part of the On-Premise ArcGISServer.ps1. It was removed in 3.2.0. Don't know why, but without this the service cannot start, because the user has no grants to "log on as service".