### PR TITLE
expose Invoke-DSCJob function to allow for more flexibility for modul…

### DIFF
--- a/Modules/ArcGIS/ArcGIS.psm1
+++ b/Modules/ArcGIS/ArcGIS.psm1
@@ -2930,6 +2930,6 @@ function Get-ArcGISProductDetails
     $ResultsArray
 }
 
-Export-ModuleMember -Function Get-FQDN, Invoke-DSCJob, Invoke-ArcGISConfiguration, Invoke-PublishWebApp, `
+Export-ModuleMember -Function Get-FQDN, Invoke-DSCJob, Invoke-ArcGISModule, Invoke-ArcGISConfiguration, Invoke-PublishWebApp, `
                                 Invoke-BuildArcGISAzureImage, Invoke-PublishGISService, `
-                                Get-ArcGISProductDetails, Wait-ForServiceToReachDesiredState, Get-DownloadsInstallsConfigurationData
+                                Get-ArcGISProductDetails, Wait-ForServiceToReachDesiredState

--- a/Modules/ArcGIS/ArcGIS.psm1
+++ b/Modules/ArcGIS/ArcGIS.psm1
@@ -588,6 +588,34 @@ function Get-DownloadsInstallsConfigurationData
     return $ConfigData
 }
 
+function Invoke-ArcGISModule
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    Param(
+        [ValidateSet("Install","InstallLicense","InstallLicenseConfigure","Uninstall","Upgrade")]
+        [Parameter(Position = 1)]
+        [System.String]
+        $Mode = 'InstallLicenseConfigure',
+
+        [System.Collections.Hashtable]
+        $Arguments,
+
+        [Parameter(Mandatory=$False)]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+        
+        [System.Boolean]
+        $DebugMode = $False,
+
+        [System.Boolean]
+        $UseWinRMSSL = $False
+    )
+
+    Arguments | ConvertTo-Json -Depth $Arguments.PSObject.Properties['Count'].Value | Out-File ".\deployment.json"
+    Invoke-ArcGISConfiguration -ConfigurationParametersFile ".\deployment.json" -Mode $Mode -Credential $Credential
+}
+
 function Invoke-ArcGISConfiguration
 {
     [CmdletBinding()]
@@ -2904,4 +2932,4 @@ function Get-ArcGISProductDetails
 
 Export-ModuleMember -Function Get-FQDN, Invoke-DSCJob, Invoke-ArcGISConfiguration, Invoke-PublishWebApp, `
                                 Invoke-BuildArcGISAzureImage, Invoke-PublishGISService, `
-                                Get-ArcGISProductDetails, Wait-ForServiceToReachDesiredState
+                                Get-ArcGISProductDetails, Wait-ForServiceToReachDesiredState, Get-DownloadsInstallsConfigurationData

--- a/Modules/ArcGIS/ArcGIS.psm1
+++ b/Modules/ArcGIS/ArcGIS.psm1
@@ -2902,6 +2902,6 @@ function Get-ArcGISProductDetails
     $ResultsArray
 }
 
-Export-ModuleMember -Function Get-FQDN, Invoke-ArcGISConfiguration, Invoke-PublishWebApp, `
+Export-ModuleMember -Function Get-FQDN, Invoke-DSCJob, Invoke-ArcGISConfiguration, Invoke-PublishWebApp, `
                                 Invoke-BuildArcGISAzureImage, Invoke-PublishGISService, `
                                 Get-ArcGISProductDetails, Wait-ForServiceToReachDesiredState


### PR DESCRIPTION
I could see scenarios where we would need to do more than Install, InstallLicense, and InstallLicenseConfigure through the Invoke-ArcGISConfiguration function. We may seek to InstallLicense each component, but then configure via federation. This is especially true in scenarios where we seek to pass in configuration options through an ARM template using `Microsoft.Compute/virtualMachines/extensions`. In that scenario, we do not have a clear understanding of how to implement without lower level access to submodules. We should at least have the option to work through these edge cases.