### PR TITLE
Added support for LicensePassword and LicensePasswordFilePath to ArcGIS Pro configuration

### DIFF
--- a/Modules/ArcGIS/Configurations-OnPrem/ArcGISLicense.ps1
+++ b/Modules/ArcGIS/Configurations-OnPrem/ArcGISLicense.ps1
@@ -89,7 +89,7 @@
                     ArcGIS_License "ProLicense$($Node.NodeName)"
                     {
                         LicenseFilePath =  $Node.ProLicenseFilePath
-                        LicensePassword = $null
+                        LicensePassword = $Node.ProLicensePassword
                         IsSingleUse = $True
                         Ensure = "Present"
                         Component = 'Pro'

--- a/Modules/ArcGIS/DSCResources/ArcGIS_License/ArcGIS_License.psm1
+++ b/Modules/ArcGIS/DSCResources/ArcGIS_License/ArcGIS_License.psm1
@@ -89,6 +89,11 @@ function Set-TargetResource
 	if(-not(Test-Path $LicenseFilePath)){
         throw "License file not found at $LicenseFilePath"
     }
+	if($null -ne $LicensePassword){
+		Write-Verbose $LicensePassword.GetNetworkCredential().Password
+	}else{
+		Write-Verbose "No password for license set!"
+	}
 
     if($Ensure -ieq 'Present') {
         [string]$RealVersion = @()
@@ -287,6 +292,7 @@ function Invoke-LicenseSoftware
         }
     }
     Write-Verbose "Licensing Product [$Product] using Software Authorization Utility at $SoftwareAuthExePath" -Verbose
+	Write-Verbose $LicensePassword.GetNetworkCredential().Password
     
     $Params = '-s -ver {0} -lif "{1}"' -f $Version,$licenseFilePath
     if($null -ne $LicensePassword){


### PR DESCRIPTION
In the current version of ArcGIS Powershell DSC, there is no support for the variables LicensePassword and LicensePasswordFilePath for ArcGIS Pro, even though they're described in the [Variables reference page](https://github.com/Esri/arcgis-powershell-dsc/wiki/v4.1.0-Variables-reference-page-for-JSON-configuration-files) in the wiki.

This pull request adds support for these two parameters for ArcGIS Pro.