### PR TITLE
Removed ports for internal use from FW rules

### DIFF
--- a/Modules/ArcGIS/Configurations-Azure/BaseDeploymentSingleTierConfiguration.ps1
+++ b/Modules/ArcGIS/Configurations-Azure/BaseDeploymentSingleTierConfiguration.ps1
@@ -742,7 +742,7 @@
                     Access                = "Allow" 
                     State                 = "Enabled" 
                     Profile               = ("Domain","Private","Public")
-                    LocalPort             = ("25672","44369","45671","45672")                      
+                    LocalPort             = ("45671","45672")                      
                     Protocol              = "TCP"
                 }
                 $DataStoreDependsOn += '[ArcGIS_xFirewall]Queue_DataStore_FirewallRules_OutBound'

--- a/Modules/ArcGIS/Configurations-Azure/DataStoreConfiguration.ps1
+++ b/Modules/ArcGIS/Configurations-Azure/DataStoreConfiguration.ps1
@@ -185,7 +185,7 @@
                 Access                = "Allow" 
                 State                 = "Enabled" 
                 Profile               = ("Domain","Private","Public")
-                LocalPort             = ("25672","44369","45671","45672")                      
+                LocalPort             = ("45671","45672")                      
                 Protocol              = "TCP"
             }
             $DataStoreDependsOn += '[ArcGIS_xFirewall]Queue_DataStore_FirewallRules_OutBound'

--- a/Modules/ArcGIS/Configurations-OnPrem/ArcGISDataStore.ps1
+++ b/Modules/ArcGIS/Configurations-OnPrem/ArcGISDataStore.ps1
@@ -157,7 +157,7 @@
                     Access                = "Allow" 
                     State                 = "Enabled" 
                     Profile               = ("Domain","Private","Public")
-                    LocalPort             = ("25672","44369","45671","45672")                      
+                    LocalPort             = ("45671","45672")                      
                     Protocol              = "TCP" 
                     DependsOn             = $Depends
                 }


### PR DESCRIPTION
According to the documentation the ports 25672 and 44369 are for machine internal use and should not be opened in the FW.

![image](https://github.com/Esri/arcgis-powershell-dsc/assets/889468/2973dffb-22e3-4409-8607-3627b87a294a)

https://enterprise.arcgis.com/en/system-requirements/latest/windows/pdf/ports-enterprise-deploy-dgm.pdf
https://enterprise.arcgis.com/en/data-store/latest/install/windows/ports-used-by-arcgis-data-store.htm

