### PR TITLE
Support for changing the startup type on the ArcGIS Server

### DIFF
--- a/Modules/ArcGIS/ArcGIS.psm1
+++ b/Modules/ArcGIS/ArcGIS.psm1
@@ -993,7 +993,11 @@ function Invoke-ArcGISConfiguration
                             $ServerRole = "GeneralPurposeServer"
                         }
                         $NodeToAdd["ServerRole"] = $ServerRole
-
+                        # Add ServiceStartupType if provided in the node config
+                        if ($ConfigurationParamsHashtable.ConfigData.ServiceStartupType){
+                            $ServiceStartupType = $ConfigurationParamsHashtable.ConfigData.ServiceStartupType
+                            $NodeToAdd["ServiceStartupType"] = $ServiceStartupType
+                        }
                         #Will ignore additional roles if primary role of server is anything else than GeneralPurposeServer
                         if($ServerRole -ieq "GeneralPurposeServer" -and $ConfigurationParamsHashtable.ConfigData.AdditionalServerRoles){
                             $AdditionalServerRoles = @()

--- a/Modules/ArcGIS/Configurations-OnPrem/ArcGISServer.ps1
+++ b/Modules/ArcGIS/Configurations-OnPrem/ArcGISServer.ps1
@@ -18,6 +18,11 @@
         [System.Boolean]
         $ServiceCredentialIsMSA = $false,
 
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("Automatic","AutomaticDelayedStart","Manual","Disabled")]
+        [System.String]
+        $ServiceStartupType = "Automatic",
+
         [Parameter(Mandatory=$true)]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
@@ -352,6 +357,7 @@
             IsDomainAccount = $ServiceCredentialIsDomainAccount
             IsMSAAccount = $ServiceCredentialIsMSA
             SetStartupToAutomatic = $True
+            SetServiceStartupType = $ServiceStartupType
         }
 
         $Depends += '[ArcGIS_Service_Account]Server_RunAs_Account' 

--- a/Modules/ArcGIS/DSCResources/ArcGIS_Service_Account/ArcGIS_Service_Account.psm1
+++ b/Modules/ArcGIS/DSCResources/ArcGIS_Service_Account/ArcGIS_Service_Account.psm1
@@ -59,7 +59,12 @@ function Get-TargetResource
 
         [parameter(Mandatory = $false)]
         [System.Boolean]
-        $SetStartupToAutomatic = $false
+        $SetStartupToAutomatic = $false,
+
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("Automatic","AutomaticDelayedStart","Manual","Disabled")]
+        [System.String]
+        $SetServiceStartupType = "Automatic"
 	)
 
 	$null
@@ -100,7 +105,12 @@ function Set-TargetResource
 
         [parameter(Mandatory = $false)]
         [System.Boolean]
-        $SetStartupToAutomatic = $false
+        $SetStartupToAutomatic = $false,
+
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("Automatic","AutomaticDelayedStart","Manual","Disabled")]
+        [System.String]
+        $SetServiceStartupType = "Automatic"
 	)
 
     if($Ensure -ieq 'Present') {
@@ -375,7 +385,7 @@ function Set-TargetResource
                         Set-ServiceStartupType -ServiceName 'ArcGISGeoEventGateway' -StartupType "Automatic" -Verbose
                     }
                 }else{
-                    $ServiceStartUpType = if($Name -ieq 'ArcGIS Notebook Server'){ "AutomaticDelayedStart" }else{ "Automatic" }
+                    $ServiceStartUpType = if($Name -ieq 'ArcGIS Notebook Server'){ "AutomaticDelayedStart" }else{ $SetServiceStartUpType }
                     $ServiceStartupTypeIsAuto = (Test-ServiceStartupType -ServiceName $Name -ExpectedStartupType $ServiceStartUpType -Verbose) # TODO - why is this check failing ?
                     if(-not($ServiceStartupTypeIsAuto)){
                         Write-Verbose "Setting Startup Type for $Name to '$($ServiceStartUpType)'"
@@ -439,7 +449,12 @@ function Test-TargetResource
 
         [parameter(Mandatory = $false)]
         [System.Boolean]
-        $SetStartupToAutomatic = $false
+        $SetStartupToAutomatic = $false,
+
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("Automatic","AutomaticDelayedStart","Manual","Disabled")]
+        [System.String]
+        $SetServiceStartupType = "Automatic"
 	)
 
     $result = $true

--- a/Modules/ArcGIS/DSCResources/ArcGIS_Service_Account/ArcGIS_Service_Account.schema.mof
+++ b/Modules/ArcGIS/DSCResources/ArcGIS_Service_Account/ArcGIS_Service_Account.schema.mof
@@ -10,5 +10,6 @@ class ArcGIS_Service_Account : OMI_BaseResource
 	[Write] Boolean IsDomainAccount;
 	[Write] Boolean IsMSAAccount;
 	[Write] Boolean SetStartupToAutomatic;
+	[Write, ValueMap{"Automatic","AutomaticDelayedStart","Manual","Disabled"}, Values{"Automatic","AutomaticDelayedStart","Manual","Disabled"}] String SetServiceStartupType;
 };
 


### PR DESCRIPTION
This is a minimal implementation for allowing the configuration of the ArcGIS Server service startup type. It does not allow the alteration of geoevent components nor the notebook server.

A more global implementation may consider replacing/altering the `SetStartupToAutomatic` parameter and affecting any of the DSC-controlled components.

This is intended as a use-at-your-own-risk /  YMMV / quality of life change for deployments facing CPU resource constraints.

See: <https://github.com/Esri/arcgis-powershell-dsc/issues/609>