### PR TITLE
Fix webviewruntime install check

### DIFF
--- a/Modules/ArcGIS/DSCResources/ArcGIS_Install/ArcGIS_Install.psm1
+++ b/Modules/ArcGIS/DSCResources/ArcGIS_Install/ArcGIS_Install.psm1
@@ -232,7 +232,7 @@ function Set-TargetResource
             $EdgeWebView2Runtime32Installed = "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
 			$regPathPatterns = @(
                     'HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}',
-                    'HKLM:\SOFTWARE\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}' # For 32-bit apps on 64-bit OS
+                    'HKLM:\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}' # For 32-bit apps on 64-bit OS
 			)
 			$edgeWebView2RegEntry = Get-ItemProperty -Path $regPathPatterns -ErrorAction SilentlyContinue
             if(-not($edgeWebView2RegEntry)){


### PR DESCRIPTION
The ArcGIS Pro installation would not continue if Edge WebView 2 Runtime was already installed. I did some testing and found out 

`if(-not(Test-Path $EdgeWebView2RuntimeInstalled) -and -not(Test-Path $EdgeWebView2Runtime64Installed) -and -not(Test-Path $EdgeWebView2Runtime32Installed))`
would always return False and therefore it would always try to install the Edge WebView 2 Runtime. This would then fail to install the Edge WebView 2 Runtime and not continue with the ArcGIS Pro install and Pro didn't get installed.

A few lines above I found another registry check which actually did find my already installed Edge WebView 2 Runtime so I modified that code a little and used it for this check. 

I'm not a powershell guru so please review it with care ;-)